### PR TITLE
Update Retail interface version in Decursive.toc

### DIFF
--- a/Decursive.toc
+++ b/Decursive.toc
@@ -1,5 +1,5 @@
-## Interface: 110207, 120000, 120001
-## Interface-Retail: 110207
+## Interface: 120000, 120001
+## Interface-Retail: 120000
 ## Interface-Classic: 11508
 ## Interface-bcc: 20505
 ## Interface-Mists: 50503


### PR DESCRIPTION
Without this change the addon is still marked as Incompatible in Midnight prepatch. Manually editing this version check in the latest release also fixes the issue.