### PR TITLE
juste suggestion of code style

### DIFF
--- a/Dcr_LiveList.lua
+++ b/Dcr_LiveList.lua
@@ -317,13 +317,12 @@ function LiveList.prototype:SetDebuff(UnitID, Debuff, IsCharmed) -- {{{
     -- Applications count
     if not cancompare(self.PrevDebuffApplicaton , Debuff.Applications) or self.PrevDebuffApplicaton ~= Debuff.Applications then
         -- Handle secret auras (WoW 12.0+ Midnight)
-        if Debuff.secretMode or (Debuff.Applications > 1) then
-            self.DebuffAppsFontString:SetText(Debuff.secretMode and Debuff.auraInstanceID and C_UnitAuras.GetAuraApplicationDisplayCount(UnitID, Debuff.auraInstanceID, 1) or Debuff.Applications);
-            self.PrevDebuffApplicaton = Debuff.Applications;
+        if Debuff.secretMode then
+            self.PrevDebuffApplicaton = Debuff.auraInstanceID and C_UnitAuras.GetAuraApplicationDisplayCount(UnitID, Debuff.auraInstanceID, 1) or " ";
         else
-            self.DebuffAppsFontString:SetText(" ");
-            self.PrevDebuffApplicaton = " ";
+            self.PrevDebuffApplicaton = Debuff.Applications > 1 and Debuff.Applications or " ";
         end
+        self.DebuffAppsFontString:SetText(self.PrevDebuffApplicaton);
     end
 
     -- Unit Name

--- a/Dcr_LiveList.lua
+++ b/Dcr_LiveList.lua
@@ -309,20 +309,23 @@ function LiveList.prototype:SetDebuff(UnitID, Debuff, IsCharmed) -- {{{
     end
 
     -- Raid Icon
-    if  cancompare(self.RaidTargetIndex, self.PrevRaidTargetIndex) and self.PrevRaidTargetIndex ~= self.RaidTargetIndex then
+    if cancompare(self.RaidTargetIndex, self.PrevRaidTargetIndex) and self.PrevRaidTargetIndex ~= self.RaidTargetIndex then
         self.RaidIconTexture:SetTexture(self.RaidTargetIndex and DC.RAID_ICON_TEXTURE_LIST[self.RaidTargetIndex] or nil);
         self.PrevRaidTargetIndex = self.RaidTargetIndex;
     end
 
     -- Applications count
-    if not cancompare(self.PrevDebuffApplicaton , Debuff.Applications) or self.PrevDebuffApplicaton ~= Debuff.Applications then
-        -- Handle secret auras (WoW 12.0+ Midnight)
-        if Debuff.secretMode then
-            self.PrevDebuffApplicaton = Debuff.auraInstanceID and C_UnitAuras.GetAuraApplicationDisplayCount(UnitID, Debuff.auraInstanceID, 1) or " ";
+    if not cancompare(self.PrevDebuffApplicaton, Debuff.Applications) or self.PrevDebuffApplicaton ~= Debuff.Applications then
+        self.PrevDebuffApplicaton = Debuff.Applications -- in such case I like to put this right after the diff check (remember that this part of Decursive's code is about 20 years old, my coding standards have evolved since I wrote that of course - so don't be surprised if I sound picky while some part of the code are clearly ugly^^)
+
+        local appDisplayString -- you should even put this in an upvalue above the function to avoid the local creation
+       
+        if Debuff.secretMode then -- Handle secret auras (WoW 12.0+ Midnight)
+            appDisplayString = Debuff.auraInstanceID and C_UnitAuras.GetAuraApplicationDisplayCount(UnitID, Debuff.auraInstanceID, 1) or "" -- I think it's better to use an empty string as it might be optimized on the C side
         else
-            self.PrevDebuffApplicaton = Debuff.Applications > 1 and Debuff.Applications or " ";
+            appDisplayString = Debuff.Applications > 1 and Debuff.Applications or ""
         end
-        self.DebuffAppsFontString:SetText(self.PrevDebuffApplicaton);
+        self.DebuffAppsFontString:SetText(appDisplayString)
     end
 
     -- Unit Name

--- a/Dcr_LiveList.lua
+++ b/Dcr_LiveList.lua
@@ -316,10 +316,8 @@ function LiveList.prototype:SetDebuff(UnitID, Debuff, IsCharmed) -- {{{
 
     -- Applications count
     if not cancompare(self.PrevDebuffApplicaton, Debuff.Applications) or self.PrevDebuffApplicaton ~= Debuff.Applications then
-        self.PrevDebuffApplicaton = Debuff.Applications -- in such case I like to put this right after the diff check (remember that this part of Decursive's code is about 20 years old, my coding standards have evolved since I wrote that of course - so don't be surprised if I sound picky while some part of the code are clearly ugly^^)
-
-        local appDisplayString -- you should even put this in an upvalue above the function to avoid the local creation
-       
+        self.PrevDebuffApplicaton = Debuff.Applications
+        local appDisplayString 
         if Debuff.secretMode then -- Handle secret auras (WoW 12.0+ Midnight)
             appDisplayString = Debuff.auraInstanceID and C_UnitAuras.GetAuraApplicationDisplayCount(UnitID, Debuff.auraInstanceID, 1) or "" -- I think it's better to use an empty string as it might be optimized on the C side
         else

--- a/Dcr_LiveList.lua
+++ b/Dcr_LiveList.lua
@@ -317,9 +317,9 @@ function LiveList.prototype:SetDebuff(UnitID, Debuff, IsCharmed) -- {{{
     -- Applications count
     if not cancompare(self.PrevDebuffApplicaton, Debuff.Applications) or self.PrevDebuffApplicaton ~= Debuff.Applications then
         self.PrevDebuffApplicaton = Debuff.Applications
-        local appDisplayString 
-        if Debuff.secretMode then -- Handle secret auras (WoW 12.0+ Midnight)
-            appDisplayString = Debuff.auraInstanceID and C_UnitAuras.GetAuraApplicationDisplayCount(UnitID, Debuff.auraInstanceID, 1) or "" -- I think it's better to use an empty string as it might be optimized on the C side
+        local appDisplayString
+        if Debuff.secretMode then
+            appDisplayString = Debuff.auraInstanceID and C_UnitAuras.GetAuraApplicationDisplayCount(UnitID, Debuff.auraInstanceID, 1) or ""
         else
             appDisplayString = Debuff.Applications > 1 and Debuff.Applications or ""
         end


### PR DESCRIPTION
if found that way more friendly, juste need your validation about store `self.PrevDebuffApplicaton` juste befor `self.DebuffAppsFontString:SetText` 


i found that is more simple write way but self.PrevDebuffApplicaton is assigned juste 1 OP befor Text as really apply, does it's okey for you ? 


tryed to ask to AI to tranlate in better english what i exactly except for this :

The refactoring improves readability, eliminates SetText duplication, and fixes a potential bug where the cached value (PrevDebuffApplicaton) did not match what was actually displayed on screen, which could prevent future updates from triggering correctly
