### PR TITLE
Add Titan Reforged 38002 compatibility

### DIFF
--- a/DCR_init.lua
+++ b/DCR_init.lua
@@ -522,7 +522,7 @@ local function SetRuntimeConstants_Once () -- {{{
                     Better = 0,
                     Pet = false,
                 },
-                [not DC.BCC and DSI["SPELL_REMOVE_GREATER_CURSE"]] = { -- WOW CLASSIC https://www.wowhead.com/classic/spell=412113/remove-greater-curse
+                [not DC.BCC and not DC.WOTLK and DSI["SPELL_REMOVE_GREATER_CURSE"]] = { -- WOW CLASSIC https://www.wowhead.com/classic/spell=412113/remove-greater-curse
                     Types = {DC.CURSE, DC.MAGIC},
                     Better = 1,
                     Pet = false,
@@ -589,7 +589,7 @@ local function SetRuntimeConstants_Once () -- {{{
                     Pet = false,
                 },
                 -- Priest
-                [DSI["SPELL_CURE_DISEASE_SHAMAN"]] = { -- WOW CLASSIC  https://classic.wowhead.com/spell=2870/cure-disease
+                [not DC.WOTLK and DSI["SPELL_CURE_DISEASE_SHAMAN"]] = { -- WOW CLASSIC  https://classic.wowhead.com/spell=2870/cure-disease
                     Types = {DC.DISEASE},
                     Better = 0,
                     Pet = false,
@@ -601,8 +601,9 @@ local function SetRuntimeConstants_Once () -- {{{
                     Pet = false,
                 },
                 -- Shaman
+                -- in WotLK this spell is Cure Toxins and also removes a disease
                 [DSI["SPELL_CURE_POISON_SHAMAN"]] = { -- WOW CLASSIC  https://classic.wowhead.com/spell=526/cure-poison
-                    Types = {DC.POISON},
+                    Types = DC.WOTLK and {DC.POISON, DC.DISEASE} or {DC.POISON},
                     Better = 0,
                     Pet = false,
                 },
@@ -2016,7 +2017,7 @@ function D:SetSpellsTranslations(FromDIAG) -- {{{
                 -- The new and changed spells in classic {{{
                 T._C.DSI["SPELL_REMOVE_CURSE_DRUID"]  = 2782;
                 T._C.DSI["SPELL_REMOVE_CURSE_MAGE"]   = 475;
-                if not DC.BCC then
+                if not DC.BCC and not DC.WOTLK then
                     T._C.DSI["SPELL_REMOVE_GREATER_CURSE"]= 412113; --  WoW SoD
                 end
                 T._C.DSI["SPELL_PURGE"]               = 370;
@@ -2028,21 +2029,28 @@ function D:SetSpellsTranslations(FromDIAG) -- {{{
                 T._C.DSI["SPELL_ABOLISH_DISEASE"]     = 552;
                 T._C.DSI["SPELL_ABOLISH_POISON"]      = 2893;
                 T._C.DSI["SPELL_CURE_DISEASE_PRIEST"] = 528;
-                T._C.DSI["SPELL_CURE_DISEASE_SHAMAN"] = 2870;
+                if not DC.WOTLK then -- merged into Cure Toxins (526) by patch 3.1
+                    T._C.DSI["SPELL_CURE_DISEASE_SHAMAN"] = 2870;
+                end
                 T._C.DSI["SPELL_CURE_POISON_SHAMAN"]  = 526;
                 T._C.DSI["SPELL_CURE_POISON_DRUID"]   = 8946;
                 T._C.DSI["PET_DEVOUR_MAGIC"]          = 19505;
                 T._C.DSI["SONICBURST"]                = 8281;
                 T._C.DSI["CRIPLES"]                   = 11443;
-                T._C.DSI["Shadowmeld"]                = 20580;
+                T._C.DSI["Shadowmeld"]                = DC.WOTLK and 58984 or 20580;
                 T._C.DSI["SPELL_DISPELL_MAGIC_PRIEST_R2"] = 988;
                 -- }}}
 
                 T._C.EXPECTED_DUPLICATES = {
-                    {"SPELL_CURE_DISEASE_PRIEST", "SPELL_CURE_DISEASE_SHAMAN"},
-                    {"SPELL_CURE_POISON_SHAMAN", "SPELL_CURE_POISON_DRUID"},
                     {"SPELL_DISPELL_MAGIC", "SPELL_DISPELL_MAGIC_PRIEST_R2"},
                 }
+
+                if not DC.WOTLK then
+                    -- in WotLK the Shaman's Cure Disease is gone and Cure Toxins (526) no
+                    -- longer shares the Druid's Cure Poison (8946) name
+                    table.insert(T._C.EXPECTED_DUPLICATES, {"SPELL_CURE_DISEASE_PRIEST", "SPELL_CURE_DISEASE_SHAMAN"});
+                    table.insert(T._C.EXPECTED_DUPLICATES, {"SPELL_CURE_POISON_SHAMAN", "SPELL_CURE_POISON_DRUID"});
+                end
 
             else
                 T._C.DSI = {

--- a/Dcr_DIAG.lua
+++ b/Dcr_DIAG.lua
@@ -668,8 +668,10 @@ T._CatchAllErrors = false;
 T._tocversion = tocversion;
 
 DC.WOWC = WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE
-DC.WOTLK = WOW_PROJECT_WRATH_CLASSIC ~= nil and WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC -- https://wowpedia.fandom.com/wiki/WOW_PROJECT_ID
-DC.CATACLYSM = WOW_PROJECT_CATACLYSM_CLASSIC ~= nil and WOW_PROJECT_ID >= WOW_PROJECT_CATACLYSM_CLASSIC
+-- Titan Reforged uses 38xxx TOCs but follows WotLK class and spell behavior.
+DC.TITAN = tocversion >= 38000 and tocversion < 40000
+DC.WOTLK = DC.TITAN or (WOW_PROJECT_WRATH_CLASSIC ~= nil and WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC) -- https://wowpedia.fandom.com/wiki/WOW_PROJECT_ID
+DC.CATACLYSM = not DC.TITAN and WOW_PROJECT_CATACLYSM_CLASSIC ~= nil and WOW_PROJECT_ID >= WOW_PROJECT_CATACLYSM_CLASSIC
 DC.TWW = tocversion >= 110000
 DC.MN = tocversion >= 120000
 DC.BCC = tocversion >= 20505 and tocversion < 30000
@@ -1043,7 +1045,8 @@ do
         local DcrMinMidTOC = tonumber(GetAddOnMetadata("Decursive", "X-Mid-Interface") or 50503);
 
         -- test if Decursive is backward compatible with the client's version
-        if tocversion < DcrMinTOC or tocversion > 30000 and tocversion < DcrMinMidTOC then
+        -- Allow supported WotLK-compatible clients in the mid-classic version gap.
+        if (tocversion < DcrMinTOC or (tocversion > 30000 and tocversion < DcrMinMidTOC)) and not DC.WOTLK then
             table.insert(Errors, ("Your World of Warcraft client version (%d) is too old to run this version of Decursive.\n"):format(tocversion));
             GenericErrorMessage2 = "You need to install an older version of Decursive.";
             FatalOccured = true;

--- a/Decursive.toc
+++ b/Decursive.toc
@@ -2,6 +2,7 @@
 ## Interface-Retail: 120007
 ## Interface-Classic: 11509
 ## Interface-bcc: 20506
+## Interface-Wrath: 38002
 ## Interface-Mists: 50504
 ## X-Max-Interface: 120007
 ## X-Min-Interface: 11509


### PR DESCRIPTION
## What changed

- Declare support for the Titan Reforged client interface version `38002`.
- Detect `38xxx` clients as Titan Reforged and route them through the existing WotLK-compatible class and spell paths.
- Prevent Titan Reforged from being classified as Cataclysm Classic.
- Allow WotLK-compatible clients through the mid-Classic interface-version compatibility gap.

## Why

Titan Reforged reports a `38xxx` TOC version. The existing compatibility check treats that range as unsupported because it lies between the legacy and Mists Classic interface ranges. Depending on its project ID, it can also fall through to Cataclysm-specific behavior even though its class and spell behavior matches WotLK.

## Impact

Decursive can load on Titan Reforged interface `38002` and reuse its existing WotLK-compatible behavior. Other Classic and Retail version checks remain unchanged.

## Validation

- `git diff --check`
- Tested in game on the Titan Reforged client with interface version `38002`.
- Confirmed the modified `Dcr_DIAG.lua` and `Decursive.toc` match the installed addon copy under the Titan Reforged game client.

Lua compiler-based syntax checks were not available in the local environment.
